### PR TITLE
HOCS-1751

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,32 +1,45 @@
 #!/bin/bash
 
-export KUBE_NAMESPACE=${KUBE_NAMESPACE}
 export KUBE_SERVER=${KUBE_SERVER}
 
 if [[ -z ${VERSION} ]] ; then
     export VERSION=${IMAGE_VERSION}
 fi
 
-if [[ ${ENVIRONMENT} == "prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_PROD drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_PROD}
+if [[ ${ENVIRONMENT} == "cs-prod" ]] ; then
+    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_CS_PROD drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_PROD}
     export REPLICAS="2"
+elif [[ ${ENVIRONMENT} == "wcs-prod" ]] ; then
+    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_WCS_PROD drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_PROD}
+    export REPLICAS="2"
+elif [[ ${ENVIRONMENT} == "cs-qa" ]] ; then
+    echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_CS_QA drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_QA}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "wcs-qa" ]] ; then
+    echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_WCS_QA drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_QA}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "cs-demo" ]] ; then
+    echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_CS_DEMO drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_DEMO}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "wcs-demo" ]] ; then
+    echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_WCS_DEMO drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_DEMO}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "cs-dev" ]] ; then
+    echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_CS_DEV drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_DEV}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "wcs-dev" ]] ; then
+    echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_WCS_DEV drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_DEV}
+    export REPLICAS="1"
 else
-    if [[ ${ENVIRONMENT} == "qa" ]] ; then
-        echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_QA drone secret"
-        export KUBE_TOKEN=${HOCS_TEMPLATES_QA}
-        export REPLICAS="1"
-    elif [[ ${ENVIRONMENT} == "demo" ]] ; then
-        echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_DEMO drone secret"
-        export KUBE_TOKEN=${HOCS_TEMPLATES_DEMO}
-        export REPLICAS="1"
-    elif [[ ${ENVIRONMENT} == "dev" ]] ; then
-        echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_DEV drone secret"
-        export KUBE_TOKEN=${HOCS_TEMPLATES_DEV}
-        export REPLICAS="1"
-    else
-        echo "Unable to find environment: ${ENVIRONMENT}"
-    fi
+    echo "Unable to find environment: ${ENVIRONMENT}"
 fi
 
 if [[ -z ${KUBE_TOKEN} ]] ; then

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -36,11 +36,11 @@ spec:
           args:
             - --certs=/certs
             - --command=/usr/bin/create-keystore.sh /certs/tls.pem /certs/tls-key.pem /etc/ssl/certs/acp-root.crt
-            - --domain=hocs-templates.${KUBE_NAMESPACE}.svc.cluster.local
+            - --domain=hocs-templates.${ENVIRONMENT}.svc.cluster.local
             - --domain=localhost
             - --onetime=true
           env:
-            - name: KUBE_NAMESPACE
+            - name: ENVIRONMENT
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -71,11 +71,11 @@ spec:
                 - SETGID
           args:
             - --certs=/certs
-            - --domain=hocs-templates.${KUBE_NAMESPACE}.svc.cluster.local
+            - --domain=hocs-templates.${ENVIRONMENT}.svc.cluster.local
             - --expiry=8760h
             - --command=/usr/local/scripts/trigger_nginx_reload.sh
           env:
-            - name: KUBE_NAMESPACE
+            - name: ENVIRONMENT
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -153,7 +153,7 @@ spec:
                 - SETGID
           env:
             - name: JAVA_OPTS
-              value: '-Xms384m -Xmx1536m -XX:+UseG1GC -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+              value: '-Xms384m -Xmx1536m -XX:+UseG1GC -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.ENVIRONMENT}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.ENVIRONMENT}}.svc.cluster.local'
             - name: JDK_TRUST_FILE
               value: '/etc/keystore/truststore.jks'
             - name: SERVER_PORT
@@ -161,11 +161,11 @@ spec:
             - name: ENDPOINTS_INFO_ENABLED
               value: 'false'
             - name: HOCS_CASE_SERVICE
-              value: 'https://hocs-casework.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+              value: 'https://hocs-casework.{{.ENVIRONMENT}}.svc.cluster.local'
             - name: HOCS_INFO_SERVICE
-              value: 'https://hocs-info-service.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+              value: 'https://hocs-info-service.{{.ENVIRONMENT}}.svc.cluster.local'
             - name: HOCS_DOCUMENT_SERVICE
-              value: 'https://hocs-docs.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+              value: 'https://hocs-docs.{{.ENVIRONMENT}}.svc.cluster.local'
             - name: HOCS_BASICAUTH
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Removed the kube namespace variable and replacing with the environment, which will now have the namespace.
This is due to the fact that filtering can only happen on the environment variable, and we need to do so due to the new tokens per service (breakup for billing).
The drone commands will change too.