### PR TITLE
HOCS-1751

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,32 +1,46 @@
 #!/bin/bash
 
-export KUBE_NAMESPACE=${KUBE_NAMESPACE}
+export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}
 
 if [[ -z ${VERSION} ]] ; then
     export VERSION=${IMAGE_VERSION}
 fi
 
-if [[ ${ENVIRONMENT} == "prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_PROD drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_PROD}
+if [[ ${ENVIRONMENT} == "cs-prod" ]] ; then
+    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_CS_PROD drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_PROD}
     export REPLICAS="2"
+elif [[ ${ENVIRONMENT} == "wcs-prod" ]] ; then
+    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_WCS_PROD drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_PROD}
+    export REPLICAS="2"
+elif [[ ${ENVIRONMENT} == "cs-qa" ]] ; then
+    echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_CS_QA drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_QA}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "wcs-qa" ]] ; then
+    echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_WCS_QA drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_QA}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "cs-demo" ]] ; then
+    echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_CS_DEMO drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_DEMO}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "wcs-demo" ]] ; then
+    echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_WCS_DEMO drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_DEMO}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "cs-dev" ]] ; then
+    echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_CS_DEV drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_DEV}
+    export REPLICAS="1"
+elif [[ ${ENVIRONMENT} == "wcs-dev" ]] ; then
+    echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_WCS_DEV drone secret"
+    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_DEV}
+    export REPLICAS="1"
 else
-    if [[ ${ENVIRONMENT} == "qa" ]] ; then
-        echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_QA drone secret"
-        export KUBE_TOKEN=${HOCS_TEMPLATES_QA}
-        export REPLICAS="1"
-    elif [[ ${ENVIRONMENT} == "demo" ]] ; then
-        echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_DEMO drone secret"
-        export KUBE_TOKEN=${HOCS_TEMPLATES_DEMO}
-        export REPLICAS="1"
-    elif [[ ${ENVIRONMENT} == "dev" ]] ; then
-        echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_DEV drone secret"
-        export KUBE_TOKEN=${HOCS_TEMPLATES_DEV}
-        export REPLICAS="1"
-    else
-        echo "Unable to find environment: ${ENVIRONMENT}"
-    fi
+    echo "Unable to find environment: ${ENVIRONMENT}"
 fi
 
 if [[ -z ${KUBE_TOKEN} ]] ; then


### PR DESCRIPTION
The environment variable will now contain the value of the namespace (like wcs-qa, not just qa).
The reason behind this is the ability to filter the namespace on deployment as we now must used different tokens for each.