### PR TITLE
HOCS-1925

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -173,10 +173,10 @@ spec:
                   key: plaintext
           resources:
             limits:
-              cpu: 850m
-              memory: 1536Mi
+              cpu: 1200m
+              memory: 2048Mi
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 512Mi
           ports:
             - name: http


### PR DESCRIPTION
The new DCU data has caused the system to hit memory and cpu usage limits (lots of recycling on the services and also errors on the automated tests).
This service is one of many to be changed so that the system is able to handle the new data volume.