### PR TITLE
HOCS-2576: remove environment if/else tower

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,7 @@
 
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}
+export KUBE_TOKEN=${KUBE_TOKEN}
 
 if [[ -z ${VERSION} ]] ; then
     export VERSION=${IMAGE_VERSION}
@@ -14,37 +15,6 @@ then
 else
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
-fi
-
-if [[ ${ENVIRONMENT} == "cs-prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_CS_PROD drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_PROD}
-elif [[ ${ENVIRONMENT} == "wcs-prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_TEMPLATES_WCS_PROD drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_PROD}
-elif [[ ${ENVIRONMENT} == "cs-qa" ]] ; then
-    echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_CS_QA drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_QA}
-elif [[ ${ENVIRONMENT} == "wcs-qa" ]] ; then
-    echo "deploy ${VERSION} to QA namespace, using HOCS_TEMPLATES_WCS_QA drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_QA}
-elif [[ ${ENVIRONMENT} == "cs-demo" ]] ; then
-    echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_CS_DEMO drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_DEMO}
-elif [[ ${ENVIRONMENT} == "wcs-demo" ]] ; then
-    echo "deploy ${VERSION} to DEMO namespace, using HOCS_TEMPLATES_WCS_DEMO drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_DEMO}
-elif [[ ${ENVIRONMENT} == "cs-dev" ]] ; then
-    echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_CS_DEV drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_CS_DEV}
-elif [[ ${ENVIRONMENT} == "wcs-dev" ]] ; then
-    echo "deploy ${VERSION} to DEV namespace, using HOCS_TEMPLATES_WCS_DEV drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_WCS_DEV}
-elif [[ ${ENVIRONMENT} == "hocs-qax" ]] ; then
-    echo "deploy ${VERSION} to qax namespace, using HOCS_TEMPLATES_QAX drone secret"
-    export KUBE_TOKEN=${HOCS_TEMPLATES_QAX}
-else
-    echo "Unable to find environment: ${ENVIRONMENT}"
 fi
 
 if [[ -z ${KUBE_TOKEN} ]] ; then


### PR DESCRIPTION
In the new drone-v1 pipeline we pass in the `KUBE_TOKEN` secret in. As a result of this we no longer need to have the if/else tower to export this.