### PR TITLE
HOCS-2576 Add "unofficial strict mode"

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}


### PR DESCRIPTION
This makes Bash exit early on an undefined variable or a non-zero exit code.