### PR TITLE
HOCS-2576: remove version param

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,10 +4,7 @@ set -euo pipefail
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
-
-if [[ -z ${VERSION} ]] ; then
-    export VERSION=${IMAGE_VERSION}
-fi
+export VERSION=${VERSION}
 
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then


### PR DESCRIPTION
Currently we check to see if the `VERSION` parameter is specified. If it
isn't we then set it to the `IMAGE_VERSION` parameter. This change
consolidates these into just the one `IMAGE_VERSION` paramater.