### PR TITLE
HOCS-2239: downscaler annotation addition

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,9 +10,11 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export MIN_REPLICAS="2"
     export MAX_REPLICAS="6"
+    export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
 else
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
+    export UPTIME_PERIOD="Mon-Fri 08:00-18:00 Europe/London"
 fi
 
 if [[ -z ${KUBE_TOKEN} ]] ; then

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hocs-templates
   labels:
     version: {{.VERSION}}
+  annotations:
+    downscaler/uptime: {{.UPTIME_PERIOD}}
 spec:
   replicas: {{.MIN_REPLICAS}}
   selector:


### PR DESCRIPTION
Presently, when the deployment changes the downscaler annotation 
(that was manually added up to present) gets removed. This causes 
pod to stay up indefinitely, which leads to increased costs and 
potential issues. This change enforced the uptime meta-data 
annotation that enforces this server stays up. This is specified 
differently depending on if we are in prod or notprod.